### PR TITLE
Sets a default value to message option.

### DIFF
--- a/Notification/EmailNotification.php
+++ b/Notification/EmailNotification.php
@@ -33,13 +33,13 @@ class EmailNotification extends AbstractApiNotification
                 'encryption'  => null,
                 'cc'          => null,
                 'bcc'         => null,
+                'message'     => null,
                 'htmlMessage' => null,
                 'attachments' => null,
             ))
             ->setRequired(array(
                 'to',
                 'subject',
-                'message',
             ))
             ->setAllowedTypes(array(
                 'port' => array('null', 'integer'),


### PR DESCRIPTION
Sometimes, the EmailNotification is called without "message" option ("htmlMessage" option used).
Since Symfony 2.8, the option resolver returns an exception if a required option is not set.
To avoid this exception, the "message" option has a default value to null.